### PR TITLE
SUPPORT-2440: Updated fusioncharts dependency from 4.1.1 to 4.2.0-beta.7

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "babel-jest": "^29.7.0",
     "babel-preset-react-native": "^4.0.1",
     "css-loader": "^6.9.1",
-    "fusioncharts": "^4.1.1",
+    "fusioncharts": "^4.2.0-alpha.0",
     "gulp": "^4.0.2",
     "gulp-clean": "^0.4.0",
     "gulp-remove-files": "0.0.3",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "babel-jest": "^29.7.0",
     "babel-preset-react-native": "^4.0.1",
     "css-loader": "^6.9.1",
-    "fusioncharts": "^4.2.0-alpha.0",
+    "fusioncharts": "^4.2.0-beta.7",
     "gulp": "^4.0.2",
     "gulp-clean": "^0.4.0",
     "gulp-remove-files": "0.0.3",


### PR DESCRIPTION
Description:
This PR addresses an issue where FusionCharts were not rendering correctly on iOS and Android devices when using the react-native-fusioncharts library.
 
Issue:
- Charts were not rendering in React Native apps using react-native-fusioncharts, although the chart container was visible.
- The issue was reproducible on a fresh sample app using React Native 0.74.5 and the official setup instructions from the react-native-fusioncharts GitHub repository.

 
Root Cause:
- Internally, FusionCharts loads its core scripts via a browser environment simulated by React Native's WebView.
- These scripts rely on Webpack’s public path to determine the base URL for loading assets.
- Webpack automatically injects a public path script that assumes a full-featured browser environment.
- React Native's WebView lacks certain capabilities of a complete browser, leading to a failure in executing Webpack’s public path logic.
- This results in FusionCharts failing to initialize, preventing the charts from rendering.

 
Fix Implemented:
- Added an explicit webpack public path assignment in the FusionCharts core (fusioncharts-xt) library to ensure compatibility in non-browser-like environments (e.g., React Native WebView).
- Updated the FusionCharts library version to 4.2.0-beta.7 in react-native-fusioncharts that includes the fix.
- No code changes were required in the app logic.
- The added change has been tested locally and validated over multiple chart types to confirm rendering was unaffected across the board.

 
Impact:
- Charts now render successfully on both iOS and Android devices.
- Compatible with the latest React Native versions.
- This change ensures robust WebView support across all mobile platforms.