### PR TITLE
chore: pin tag-version-prefix so npm version creates bare tags

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,4 @@
+# Tags in this repository are bare, with no "v" prefix.
+# npm's built-in default for tag-version-prefix is "v", so without this line
+# `npm version 7.0.0` would create a tag named "v7.0.0" and break the convention.
+tag-version-prefix=


### PR DESCRIPTION
## What

Adds a repository `.npmrc` containing a single setting:

```
tag-version-prefix=
```

## Why

`npm version <x>` does not just edit `package.json`. It also creates a git tag,
and it names that tag using npm's `tag-version-prefix` setting.

**npm's built-in default for that setting is `v`.** Every tag in this repository
is bare, with no prefix. So running `npm version` at release time would create a
tag like `vX.Y.Z`, inconsistent with every existing tag here.

This file makes the correct behaviour automatic.

## Why a file in the repo rather than a machine setting

A machine-level `npm config set` only helps on that one machine. Publishing from
a different machine, or by a different person, would silently reintroduce the
prefix. Committing the setting means it travels with the code and applies to
everyone.

## Verification

- `npm config get tag-version-prefix` now returns an empty string in this
  repository. It returned `v` before.
- Confirmed end to end in a scratch repository: with this file present,
  `npm version` creates a bare tag.
- **The file is not published.** npm excludes `.npmrc` from every tarball
  unconditionally, independent of any `files` list or `.npmignore`. Checked with
  `npm pack --dry-run`.

## Context

Part of a fleet-wide tag audit. All four FusionCharts wrapper repositories were
standardised on bare tags, and this pins that convention so the next release
cannot undo it by accident.
